### PR TITLE
Symfony 3.4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- services.yml updated to Symfony 3.4 best practices
+
 ## [0.1.2] - 2018-02-12
 ### Fixed
 - Fix availability value (@simara-svatopluk)

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,15 +1,16 @@
 services:
-  shopsys.product_feed.google_bundle.feed_config:
-    class: Shopsys\ProductFeed\GoogleBundle\GoogleFeedConfig
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Shopsys\ProductFeed\GoogleBundle\:
+    resource: '../*'
+
+  Shopsys\ProductFeed\GoogleBundle\GoogleFeedConfig:
     tags:
       - { name: shopsys.product_feed }
 
-  shopsys.product_feed.google_bundle.product_crud_extension:
-    class: Shopsys\ProductFeed\GoogleBundle\GoogleProductCrudExtension
+  Shopsys\ProductFeed\GoogleBundle\GoogleProductCrudExtension:
     tags:
       - { name: shopsys.crud_extension, type: product }
-
-  shopsys.product_feed.google_bundle.product_form_type:
-    class: Shopsys\ProductFeed\GoogleBundle\GoogleProductFormType
-    tags:
-      - { name: form.type }


### PR DESCRIPTION
**Description, reason for the PR:** upgrade of the main repository to Symfony 3.4

**New feature:** No

**BC breaks:** No

**Fixes issues:** None

**Standards and tests pass:** Yes

**License:** MIT
